### PR TITLE
:bug: 처음 화면에서 로그인되지 않고, 글 작성시 밀리던 이슈

### DIFF
--- a/src/containers/write/EditorContainer.jsx
+++ b/src/containers/write/EditorContainer.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useCallback } from 'react';
 import { withRouter } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
-import { initialize, changeField } from '../../modules/write';
+import { initialize, changeField, clear } from '../../modules/write';
 import Editor from '../../components/write/Editor';
 
 function EditorContainer({ match }) {
@@ -20,7 +20,8 @@ function EditorContainer({ match }) {
   );
 
   useEffect(() => {
-    return () => dispatch(initialize(owner));
+    dispatch(initialize(owner));
+    return () => dispatch(clear());
   }, [dispatch, owner]);
 
   return <Editor title={title} body={body} onChangeField={onChangeField} />;

--- a/src/modules/write.js
+++ b/src/modules/write.js
@@ -3,6 +3,7 @@ import createRequestSaga, { createRequestActionTypes } from '../lib/createReques
 import * as postsAPI from '../lib/api/posts';
 
 const INITIALIZE = 'write/INITIALIZE';
+const CLEAR = 'write/CLEAR';
 const CHANGE_FIELD = 'write/CHANGE_FIELD';
 const SET_ORIGINAL_POST = 'write/SET_ORIGINAL_POST';
 
@@ -10,6 +11,7 @@ const [WRITE_POST, WRITE_POST_SUCCESS, WRITE_POST_FAILURE] = createRequestAction
 const [UPDATE_POST, UPDATE_POST_SUCCESS, UPDATE_POST_FAILURE] = createRequestActionTypes('write/UPDATE_POST');
 
 export const initialize = (owner) => ({ type: INITIALIZE, payload: owner });
+export const clear = () => ({ type: CLEAR });
 export const changeField = ({ key, value }) => ({ type: CHANGE_FIELD, payload: { key, value } });
 export const setOriginalPost = (post) => ({ type: SET_ORIGINAL_POST, payload: post });
 
@@ -36,7 +38,9 @@ const initialState = {
 export default function write(state = initialState, action) {
   switch (action.type) {
     case INITIALIZE:
-      return { ...initialState, owner: action.payload };
+      return { ...state, owner: action.payload };
+    case CLEAR:
+      return { ...initialState };
     case CHANGE_FIELD:
       return { ...state, [action.payload.key]: action.payload.value };
     case SET_ORIGINAL_POST:


### PR DESCRIPTION
 - 원인: 글 작성 페이지 들어갔을 때, 초기화가 되지 않아서 owner 값이 설정되지 않음
 - 해결: 글 작성시 초기화 액션(owner 설정) 디스패치